### PR TITLE
fix: in Ulmo, this plugin depends on tutor 21.x.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,13 +29,13 @@ classifiers = [
 
 ]
 dependencies = [
-    "tutor >= 20,<21.0.0",
-    "tutor-mfe >= 20,<21.0.0",
+    "tutor >= 21.0.0,<22.0.0",
+    "tutor-mfe >= 21.0.0,<22.0.0",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "tutor[dev] @ git+https://github.com/overhangio/tutor.git@ulmo",
+    "tutor[dev] >= 21.0.0,<22.0.0",
     "ruff",
 ]
 


### PR DESCRIPTION
Because Ulmo is v21, this plugin should not depend on tutor<21. Also, in development, we must not mandate the installation of a specific remote branch; we only care about the fact that tutor is 21.something.