### PR TITLE
feat: added waffle to enable email notifications

### DIFF
--- a/tutornotifications/templates/notifications/tasks/lms/waffle_flags
+++ b/tutornotifications/templates/notifications/tasks/lms/waffle_flags
@@ -1,2 +1,2 @@
 # Create waffle flag to enable notifications
-(./manage.py lms waffle_flag --list | grep notifications.enable_notifications) || ./manage.py lms waffle_flag --everyone --create notifications.enable_notifications
+(./manage.py lms waffle_flag --list | grep notifications.enable_notifications) || ./manage.py lms waffle_flag --everyone --create notifications.enable_notifications; (./manage.py lms waffle_flag --list | grep notifications.enable_email_notifications) || ./manage.py lms waffle_flag --everyone --create notifications.enable_email_notifications


### PR DESCRIPTION
This PR adds patch to enable `notifications.enable_email_notifications` to make sure email notifications feature is enabled when plugin is enabled.