### PR TITLE
feat: added init command to docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Notifications plugin for `Tutor <https://docs.tutor.edly.io>`__
 
 A Tutor plugin to manage plugin slot and configuration for tray and email notifications feature. Learn
 more about it in
-`Notifications & Preferences <https://docs.openedx.org/en/latest/learners/sfd_notifications/index.html>`_ 
+`Notifications & Preferences <https://docs.openedx.org/en/latest/learners/sfd_notifications/index.html>`_
 
 
 Installation
@@ -20,6 +20,9 @@ Usage
 
     tutor plugins enable notifications
 
+.. code-block:: bash
+
+    tutor [dev|local|k8s] do init --limit notifications
 
 Configuration
 *************


### PR DESCRIPTION
This pull request adds important instructions to the `README.rst` to help users initialize the notifications plugin in both local and development environments.

Usage documentation update:

* Added code examples for initializing the notifications plugin using `tutor local do init --limit=notifications` and `tutor dev do init --limit=notifications` to clarify setup steps for different environments.