### PR TITLE
Support Verawood

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,13 +29,13 @@ classifiers = [
 
 ]
 dependencies = [
-    "tutor >= 21,<22.0.0",
-    "tutor-mfe >= 21,<22.0.0",
+    "tutor >= 21,<23.0.0",
+    "tutor-mfe >= 21,<23.0.0",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "tutor[dev]>=21.0.0,<22.0.0",
+    "tutor[dev]>=21.0.0,<23.0.0",
     "ruff",
 ]
 


### PR DESCRIPTION
fix: update tutor and tutor-mfe dependencies to allow versions up to 23.0.0